### PR TITLE
Fix issue when target resolves to multiple IPs

### DIFF
--- a/rcurl.sh
+++ b/rcurl.sh
@@ -26,7 +26,7 @@ rcurl() {
   fi
   rcurl_debug "Port:     ${port}" "$@"
 
-  target_ip="$(dns_lookup "${target}")"
+  target_ip="$(dns_lookup "${target}" | head -1)"
   if [ -z "${target_ip}" ]; then
     # if dig returned nothing then is 127.0.0.1 or something
     target_ip="${target}"


### PR DESCRIPTION
When target has multiple IPs (e.g. our AWS aliases like `alias-*.zeit.co`) `rcurl` was ignoring the `--resolve` flag completely

@hharnisc @matheuss running `now-proxy` e2e tests can yield false positives/negatives when hitting an AWS cluster